### PR TITLE
Add a php cs file

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([])
+    ->finder(
+        Symfony\CS\Finder\DefaultFinder::create()->in(__DIR__ . '/src')
+    )
+;


### PR DESCRIPTION
Proposal for a cs file see #1 and #2 

We all have our habits, way of doing thing, etc... IMO having a common style for code is necessary, however choice of rules should not take forever. Then i want to propose the following workflow for choosing coding rules : 

1) Every contributor can propose a rule in a new issue / pull request
2) Every contributor should do a vote about the rule: +1 / 0 (don't give a fuck) / -1
3) After 1 week on the proposed rule, vote are counted, and if it's win by majority (50% + 1), rule is added / removed to the cs file

(A contributor in this case is someone who belongs to the organisation)

This is mainly to avoid useless debate for something which is highly subjective.

This cs file include all psr1 and psr2 rules as the base coding style.

If workflow is agreed by everyone, i will propose some other rules.
