### PR TITLE
Exclude PHPSpec and PHPUnit test dirs from StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,9 @@
 preset: symfony
 
 finder:
+    exclude:
+        - "spec"
+        - "tests"
     path:
         - "src"
 


### PR DESCRIPTION
It seems that specifying a path is not enough.

See php-http/httplug#92

I find this behavior weird. Any ideas?
