### PR TITLE
Disable unalign_double_arrow rule from Symfony preset

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,3 +9,6 @@ finder:
 
 enabled:
     - short_array_syntax
+
+disabled:
+    - unalign_double_arrow


### PR DESCRIPTION
@joelwurtz IIRC you wanted this.

Would make sense here: https://styleci.io/analyses/XkAZAz
