### PR TITLE
sync cs-fixer rules with client-common

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,7 +12,12 @@ $finder = PhpCsFixer\Finder::create()
 ;
 return PhpCsFixer\Config::create()
     ->setRules([
-         '@Symfony' => true,
-         'array_syntax' => ['syntax' => 'short'],
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'no_empty_phpdoc' => true,
+        'no_superfluous_phpdoc_tags' => true,
     ])
     ->setFinder($finder);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | sync with https://github.com/php-http/client-common/pull/120
| Documentation   | -
| License         | MIT


#### What's in this PR?

More rules to avoid noise when we use type declarations. ported from client-common.